### PR TITLE
Pin to a version of oauth2 that does not generate an error when trying to connect

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,4 +21,4 @@ with Marketplace.
 You may find the source code and collaborate your time and experience at
 https://github.com/mozilla/Marketplace.Python
 """,
-    install_requires=['httplib2', 'oauth2', 'requests'])
+    install_requires=['httplib2', 'oauth2==1.5.211', 'requests'])


### PR DESCRIPTION
The library is not pinned to a version of oauth2, and the latest release has broken our tests [1]. You can see an example of the failures in our Jenkins [2].

This pull request pins to a version of oauth2 that does not cause this error.

@diox  If possible, please review, and if acceptable please merge and release a new package to PyPI.

[1] https://github.com/mozilla/marketplace-tests
[2] https://webqa-ci.mozilla.com/view/Buildmaster/job/marketplace.stage.developer_hub.saucelabs/423/HTML_Report/